### PR TITLE
fix: support both prefixed and non-prefixed enum values in type definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "AGPL-3.0-or-later",
   "author": "portone-dx <support@portone.io>",
   "repository": "https://github.com/portone-io/client-sdk-generator",
-  "packageManager": "pnpm@10.12.1",
+  "packageManager": "pnpm@10.12.4+sha512.5ea8b0deed94ed68691c9bad4c955492705c5eeb8a87ef86bc62c74a26b037b08ff9570f108b2e4dbd1dd1a9186fea925e527f141c648e85af45631074680184",
   "scripts": {
     "version": "changeset version && pnpm i --lockfile-only",
     "ci": "biome ci"


### PR DESCRIPTION
- Without prefix: 'CARD'
- With prefix: 'PG_CARD' (when value_prefix='PG')